### PR TITLE
Fix typo in json template

### DIFF
--- a/pi-hosted_template/template/portainer-v2.json
+++ b/pi-hosted_template/template/portainer-v2.json
@@ -1996,7 +1996,7 @@
 			],
 			"image": "linuxserver/deluge:latest",
 			"logo": "https://raw.githubusercontent.com/novaspirit/pi-hosted/main/pi-hosted_template/images/deluge-icon.png",
-			"namme": "deluge",
+			"name": "deluge",
 			"platform": "linux",
 			"restart_policy": "unless-stopped",
 			"title": "Deluge",


### PR DESCRIPTION
There is a typo in the json template.
This PR changes fixes the typo from "namme" to "name"